### PR TITLE
BeanRegistry as enum singleton, pom cleanup

### DIFF
--- a/angular-beans/pom.xml
+++ b/angular-beans/pom.xml
@@ -91,12 +91,6 @@ AngularBeans framework
 		</dependency>
 
 		<dependency>
-			<groupId>io.fastjson</groupId>
-			<artifactId>boon</artifactId>
-			<version>0.32</version>
-		</dependency>
-
-		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>13.0.1</version>

--- a/angular-beans/src/main/java/angularBeans/boot/BeanRegistry.java
+++ b/angular-beans/src/main/java/angularBeans/boot/BeanRegistry.java
@@ -24,20 +24,15 @@ import angularBeans.util.NGBean;
  *will produce the final "angular-beans.js" script.
  * @author bessem hmidi
  */
-public class BeanRegistry {
+public enum BeanRegistry {
 
-	private static BeanRegistry instance;
+	INSTANCE;
 	
 	private Set<NGBean> angularBeans;
 	private Set<NGService> extentions;
 	
 	private Class<? extends Object> appClass;
 
-	public static synchronized BeanRegistry getInstance() {
-		if(instance == null) instance = new BeanRegistry();
-		return instance;
-	}
-	
 	private BeanRegistry(){
 		if(angularBeans == null) angularBeans = new HashSet<>();
 		if(extentions == null) extentions = new HashSet<>();

--- a/angular-beans/src/main/java/angularBeans/boot/ModuleGenerator.java
+++ b/angular-beans/src/main/java/angularBeans/boot/ModuleGenerator.java
@@ -133,7 +133,7 @@ public class ModuleGenerator implements Serializable {
 		jsBuffer.append(StaticJsCache.CORE_SCRIPT);
 
 		StringBuffer beansBuffer = new StringBuffer();
-		for (NGBean mb : BeanRegistry.getInstance().getAngularBeans()) {
+		for (NGBean mb : BeanRegistry.INSTANCE.getAngularBeans()) {
 			beansBuffer.append(generateBean(mb));
 		}
 

--- a/angular-beans/src/main/java/angularBeans/context/AngularBeansCDIExtension.java
+++ b/angular-beans/src/main/java/angularBeans/context/AngularBeansCDIExtension.java
@@ -69,23 +69,23 @@ public class AngularBeansCDIExtension implements Extension {
 		
 		//Handle @AngluarBeans annotated components
 		if (annotatedType.isAnnotationPresent(AngularBean.class)){
-			BeanRegistry.getInstance().registerBean(typeClass);
-		};
+			BeanRegistry.INSTANCE.registerBean(typeClass);
+		}
 
 		//Handle @NGExtension annotated components
 		if (annotatedType.isAnnotationPresent(NGExtension.class)){
 			try {
-				BeanRegistry.getInstance().registerExtention(
+				BeanRegistry.INSTANCE.registerExtention(
 						(NGService) annotatedType.getJavaClass()
 								.newInstance());
 			} catch (InstantiationException | IllegalAccessException e) {
 				e.printStackTrace();
 			}
-		};
+		}
 
 		//Handle @NGApp annotated components
 		if (annotatedType.isAnnotationPresent(NGApp.class)) {
-			BeanRegistry.getInstance().registerApp(typeClass);
+			BeanRegistry.INSTANCE.registerApp(typeClass);
 		}
 
 	}

--- a/angular-beans/src/main/java/angularBeans/realtime/AngularBeansServletContextListener.java
+++ b/angular-beans/src/main/java/angularBeans/realtime/AngularBeansServletContextListener.java
@@ -207,7 +207,7 @@ public class AngularBeansServletContextListener implements
 		String appName = null;
 		Class<? extends Object> appClass = null;
 
-		appClass = BeanRegistry.getInstance().getAppClass();
+		appClass = BeanRegistry.INSTANCE.getAppClass();
 		if (appClass.isAnnotationPresent(Named.class)) {
 			appName = appClass.getAnnotation(Named.class).value();
 		}
@@ -247,7 +247,7 @@ public class AngularBeansServletContextListener implements
 
 	private void generateExtentions() {
 		StringBuffer buffer = new StringBuffer();
-		for (NGService extention : BeanRegistry.getInstance().getExtentions()) {
+		for (NGService extention : BeanRegistry.INSTANCE.getExtentions()) {
 
 			Method m;
 			try {

--- a/angular-beans/src/main/java/angularBeans/realtime/RealTimeClient.java
+++ b/angular-beans/src/main/java/angularBeans/realtime/RealTimeClient.java
@@ -96,7 +96,7 @@ public class RealTimeClient implements Serializable {
 		connectionHolder.getAllConnections().add(event.getConnection());
 		sessions.add(event.getConnection());
 
-		Set<NGBean> angularBeans = BeanRegistry.getInstance().getAngularBeans();
+		Set<NGBean> angularBeans = BeanRegistry.INSTANCE.getAngularBeans();
 
 		for (NGBean bean : angularBeans) {
 


### PR DESCRIPTION
A Java enum is a singleton by spec, without the usual overhead and error-proneness of a manual implementation
