### PR TITLE
added null checks

### DIFF
--- a/angular-beans/src/main/java/angularBeans/remote/InvocationHandler.java
+++ b/angular-beans/src/main/java/angularBeans/remote/InvocationHandler.java
@@ -285,7 +285,7 @@ public class InvocationHandler implements Serializable {
 
 		String[] updates = null;
 
-		if (m.isAnnotationPresent(NGReturn.class)) {
+		if (m != null && m.isAnnotationPresent(NGReturn.class)) {
 
 			if (mainReturn == null)
 				mainReturn = "";
@@ -303,7 +303,7 @@ public class InvocationHandler implements Serializable {
 			}
 		}
 
-		if (m.isAnnotationPresent(NGPostConstruct.class)) {
+		if (m != null && m.isAnnotationPresent(NGPostConstruct.class)) {
 			NGPostConstruct ngPostConstruct = m.getAnnotation(NGPostConstruct.class);
 			updates = ngPostConstruct.updates();
 

--- a/angular-beans/src/main/java/angularBeans/util/CommonUtils.java
+++ b/angular-beans/src/main/java/angularBeans/util/CommonUtils.java
@@ -127,12 +127,18 @@ public abstract class CommonUtils {
 	}
 
 	public static boolean isSetter(Method m) {
+		if (m == null) {
+			return false;
+		}
 
 		return m.getName().startsWith(SETTER_PREFIX) && returnsVoid(m)
 				&& hasOneParameter(m);
 	}
 
 	public static boolean isGetter(Method m) {
+		if (m == null) {
+			return false;
+		}
 		if (returnsVoid(m)) {
 			return false;
 		}
@@ -174,6 +180,10 @@ public abstract class CommonUtils {
 	}
 
 	private static boolean isHttpAnnotated(Method m) {
+		if (m == null) {
+			return false;
+		}
+
 		return m.isAnnotationPresent(Get.class)
 				|| m.isAnnotationPresent(Post.class)
 				|| m.isAnnotationPresent(Put.class)


### PR DESCRIPTION
Apparently `isSetter(m)` and `isGetter(m)` can be called with a `null` argument.
If `m` does not exist it is neither a setter nor a getter and both methods should return `false` instead of throwing a NPE.
