### PR TITLE
By definition the json encoding is utf-8

### DIFF
--- a/angular-beans/src/main/java/angularBeans/remote/HalfDuplexEndPoint.java
+++ b/angular-beans/src/main/java/angularBeans/remote/HalfDuplexEndPoint.java
@@ -105,6 +105,8 @@ public class HalfDuplexEndPoint extends HttpServlet implements Serializable {
 
 		AsyncContext asyncContext=request.startAsync();
 		
+		resp.setCharacterEncoding("UTF-8");
+
 		if(request.getRequestURL().toString().endsWith("/CORS")){
 			resp.addHeader("Access-Control-Allow-Origin", "*");
 			resp.addHeader("Access-Control-Allow-Methods", "POST, GET, PUT, DELETE");


### PR DESCRIPTION
By definition the json encoding is utf-8 #https : //en.wikipedia.org/wiki/JSON
