### PR TITLE
Exclude bridge method (compiler-generated to support generic interfaces)

### DIFF
--- a/angular-beans/src/main/java/angularBeans/boot/ModuleGenerator.java
+++ b/angular-beans/src/main/java/angularBeans/boot/ModuleGenerator.java
@@ -18,6 +18,7 @@ import static angularBeans.events.Callback.BEFORE_SESSION_READY;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.Set;
@@ -303,7 +304,7 @@ public class ModuleGenerator implements Serializable {
 			boolean corsEnabled = false;
 			boolean isNative = false;
 			for (Method nativeMethod : nativesMethods) {
-				if (nativeMethod.equals(m))
+				if (nativeMethod.equals(m) && !Modifier.isVolatile(m.getModifiers()))
 					isNative = true;
 			}
 

--- a/angular-beans/src/main/java/angularBeans/remote/InvocationHandler.java
+++ b/angular-beans/src/main/java/angularBeans/remote/InvocationHandler.java
@@ -15,6 +15,7 @@ import static angularBeans.util.Accessors.*;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -169,7 +170,7 @@ public class InvocationHandler implements Serializable {
 			
 			for (Method mt : service.getClass().getMethods()) {
 
-				if (mt.getName().equals(methodName)) {
+				if (mt.getName().equals(methodName) && !Modifier.isVolatile(mt.getModifiers())) {
 					m=mt;
 					Type[] parameters = mt.getParameterTypes();
 
@@ -198,10 +199,6 @@ public class InvocationHandler implements Serializable {
 							}
 
 							JsonElement element = args.get(i);
-
-							
-						
-							
 							
 							if (element.isJsonPrimitive()) {
 
@@ -240,25 +237,12 @@ public class InvocationHandler implements Serializable {
 			
 			for (Method mt : service.getClass().getMethods()) {
 
-				if (mt.getName().equals(methodName)) {
+				if (mt.getName().equals(methodName) && !Modifier.isVolatile(mt.getModifiers())) {
 
 					Type[] parameters = mt.getParameterTypes();
 
-					// handling methods that took HttpServletRequest as parameter
-					
-					if(parameters.length==1){
-							
-//						 if(mt.getParameters()[0].getType()==HttpServletRequest.class)	
-//						  {
-//							 System.out.println("hehe...");
-//							 mt.invoke(service, request);
-//						
-//						  }
-					
-						
-						
-					}
-					 else{
+					// handling methods that took HttpServletRequest as parameter					
+					if(parameters.length!=1){
 						 if (!CommonUtils.isGetter(m)) {
 								update(service, params);
 							}
@@ -266,8 +250,6 @@ public class InvocationHandler implements Serializable {
 					 }
 			
 				}}
-			
-			
 		}
 
 		ModelQueryImpl qImpl = (ModelQueryImpl) modelQueryFactory.get(service.getClass());

--- a/angular-beans/src/main/java/angularBeans/util/AngularBeansUtils.java
+++ b/angular-beans/src/main/java/angularBeans/util/AngularBeansUtils.java
@@ -10,6 +10,7 @@ import static angularBeans.util.Accessors.*;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.Calendar;
 import java.util.UUID;
@@ -142,7 +143,7 @@ class LobWrapperJsonAdapter implements JsonSerializer<LobWrapper> {
 		for (Method m : clazz.getMethods()) {
 			// TODO to many nested statement
 			if ((m.getName().startsWith(GETTER_PREFIX) || m.getName().startsWith(BOOLEAN_GETTER_PREFIX))
-					&& m.getReturnType().equals(LobWrapper.class)) {
+					&& m.getReturnType().equals(LobWrapper.class) && !Modifier.isVolatile(m.getModifiers())) {
 				try {
 
 					Call lobSource = new Call(container, m);

--- a/angular-beans/src/main/java/angularBeans/util/NGBean.java
+++ b/angular-beans/src/main/java/angularBeans/util/NGBean.java
@@ -23,6 +23,7 @@ package angularBeans.util;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -70,7 +71,7 @@ public class NGBean implements Serializable {
 		methods = targetClass.getMethods();
 
 		for (Method m : methods) {
-			if (CommonUtils.isGetter(m)) {
+			if (CommonUtils.isGetter(m) && !Modifier.isVolatile(m.getModifiers())) {
 				if (m.isAnnotationPresent(NGModel.class)) {
 					getters.add(m);
 				}


### PR DESCRIPTION
when the method has generic interfaces , this generates a mirror with the generic attribute and is eventually selected , generating json conversion error , which attempts to instantiate the generic attribute and not implemented. #https://docs.oracle.com/javase/tutorial/reflect/member/methodModifiers.html.
