### PR TITLE
Fix serializer bug; configuration file; gson exclusion strategy

### DIFF
--- a/angular-beans/src/main/java/angularBeans/util/AngularBeansUtils.java
+++ b/angular-beans/src/main/java/angularBeans/util/AngularBeansUtils.java
@@ -6,7 +6,8 @@
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details. */
 package angularBeans.util;
 
-import static angularBeans.util.Accessors.*;
+import static angularBeans.util.Accessors.BOOLEAN_GETTER_PREFIX;
+import static angularBeans.util.Accessors.GETTER_PREFIX;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
@@ -49,8 +50,9 @@ public class AngularBeansUtils implements Serializable {
 	private String contextPath;
 
 	public void initJsonSerialiser() {
-
 		GsonBuilder builder = new GsonBuilder().serializeNulls();
+		
+		builder.setExclusionStrategies(NGConfiguration.getGsonExclusionStrategy());
 
 		builder.registerTypeAdapter(LobWrapper.class, new LobWrapperJsonAdapter(cache));
 
@@ -70,11 +72,15 @@ public class AngularBeansUtils implements Serializable {
 
 	}
 
-	public String getJson(Object object) {
-
-		if (mainSerializer == null || object == null) {
+	public String getJson(Object object) {		
+		if (object == null) {
 			return null;
 		}
+		
+		if(mainSerializer == null){
+			initJsonSerialiser();
+		}
+
 		return mainSerializer.toJson(object);
 	}
 
@@ -86,8 +92,11 @@ public class AngularBeansUtils implements Serializable {
 	}
 
 	public Object deserialise(Type type, JsonElement element) {
-
-      return mainSerializer.fromJson(element, type);
+		if(mainSerializer == null){
+			initJsonSerialiser();
+		}
+		
+		return mainSerializer.fromJson(element, type);
    }
 
 	public Object convertEvent(NGEvent event) throws ClassNotFoundException {

--- a/angular-beans/src/main/java/angularBeans/util/NGConfiguration.java
+++ b/angular-beans/src/main/java/angularBeans/util/NGConfiguration.java
@@ -1,0 +1,54 @@
+package angularBeans.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import com.google.gson.ExclusionStrategy;
+
+/***
+ * Angular Beans Configuration Util
+ * 
+ * <br><br>
+ * 
+ * <b>Properties:</b> ng.properties
+ * 
+ * @author Tiago Carvalho
+ */
+public class NGConfiguration {
+	
+	private static String ANGULAR_BEANS_PROPERTIES = "ng.properties";
+	private static String GSON_EXCLUSION_STRATEGY = "gson.exclusionStrategy";
+	
+	public static String getProperty(String property) {
+		try {
+			InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(ANGULAR_BEANS_PROPERTIES);
+			
+			if(is != null){
+				Properties props = new Properties();
+				props.load(is);
+				return props.getProperty(property);
+			}
+		} catch (IOException e){
+			Logger.getLogger(NGConfiguration.class.getName()).severe(e.toString());
+		}
+		
+		return null;
+	}
+	
+	public static ExclusionStrategy[] getGsonExclusionStrategy() {
+		try{
+			String exclusionStrategyName = NGConfiguration.getProperty(GSON_EXCLUSION_STRATEGY);
+			
+			if(exclusionStrategyName != null && exclusionStrategyName.length() > 0){
+				return new ExclusionStrategy[]{(ExclusionStrategy) Class.forName(exclusionStrategyName).newInstance()};
+			}
+		} catch (Exception e){
+			Logger.getLogger(NGConfiguration.class.getName()).severe(e.toString());
+		}
+
+		// Needs to return empty array explicitly instead of null because of GsonBuilder's setExclusionStrategies() varargs
+		return new ExclusionStrategy[]{};
+	}
+}


### PR DESCRIPTION
(1) fix serializer bug which required a page refresh after each deploy;
(2) add AngularBeans configuration file 'ng.properties';
(3) add gson exclusion strategy to exclude fields from serialization/deserialization, which is read from the new configuration file;
## 

As an example:
1. it was created the file 'ng.properties' in web project 'src/main/resources' with property gson.exclusionStrategy=<class qualified name>
2. The above exclusion class was created in another project - together with an @GsonIgnore annotation -, dependency of the web project (war)
3. AngularBeans GsonBuilder now uses the provided class
4. ng.properties can be used for further configurations
